### PR TITLE
ECS 추가

### DIFF
--- a/bin/salary-lupin-infra.ts
+++ b/bin/salary-lupin-infra.ts
@@ -5,6 +5,7 @@ import * as dotenv from "dotenv";
 import { DomainStack } from "../lib/domain/DomainStack";
 import { VpcStack } from "../lib/network/VpcStack";
 import { RdsStack } from "../lib/storage/RdsStack";
+import { BackendStack } from "../lib/backend/BackendStack";
 
 const environment = process.env.NODE_ENV ?? "dev";
 dotenv.config({ path: `env/${environment}.env` });
@@ -31,6 +32,11 @@ const rdsStack = new RdsStack(app, `RdsStack-${environment}`, {
   appName: appName,
   vpc: vpcStack.vpc,
   rdsUserName: rdsUserName,
+});
+
+const backendStack = new BackendStack(app, `BackendStack-${environment}`, {
+  environment: environment,
+  vpc: vpcStack.vpc,
 });
 
 const domainStack = new DomainStack(app, "DomainStack", {

--- a/lib/backend/BackendEcsInfra.ts
+++ b/lib/backend/BackendEcsInfra.ts
@@ -1,0 +1,60 @@
+import { Construct } from "constructs";
+import {
+  AsgCapacityProvider,
+  Cluster,
+  EcsOptimizedImage,
+} from "aws-cdk-lib/aws-ecs";
+import { AutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  SecurityGroup,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+interface BackendEcsInfraProps {
+  environment: string;
+  vpc: Vpc;
+  securityGroup: SecurityGroup;
+}
+
+export class BackendEcsInfra extends Construct {
+  public readonly cluster: Cluster;
+
+  constructor(scope: Construct, id: string, props: BackendEcsInfraProps) {
+    super(scope, id);
+
+    this.cluster = new Cluster(
+      this,
+      `Backend-Cluster-${props.environment}`,
+      {},
+    );
+
+    const autoScalingGroup = new AutoScalingGroup(
+      this,
+      `Backend-AutoScaling-Group-${props.environment}`,
+      {
+        vpc: props.vpc,
+        vpcSubnets: props.vpc.selectSubnets({
+          subnetType: SubnetType.PUBLIC,
+        }),
+        instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+        machineImage: EcsOptimizedImage.amazonLinux2(),
+        minCapacity: 0,
+        maxCapacity: 1,
+        desiredCapacity: 1,
+        securityGroup: props.securityGroup,
+      },
+    );
+
+    const capacityProvider = new AsgCapacityProvider(
+      this,
+      `Backend-ASG-CapacityProvider-${props.environment}`,
+      { autoScalingGroup: autoScalingGroup },
+    );
+
+    this.cluster.addAsgCapacityProvider(capacityProvider);
+  }
+}

--- a/lib/backend/BackendEcsTask.ts
+++ b/lib/backend/BackendEcsTask.ts
@@ -1,0 +1,31 @@
+import { Construct } from "constructs";
+import {
+  ContainerImage,
+  Ec2TaskDefinition,
+  Protocol,
+} from "aws-cdk-lib/aws-ecs";
+
+export class BackendEcsTask extends Construct {
+  public readonly taskDefinition: Ec2TaskDefinition;
+
+  constructor(scope: Construct, id: string, props: { environment: string }) {
+    super(scope, id);
+
+    this.taskDefinition = new Ec2TaskDefinition(
+      this,
+      `Backend-TaskDef-${props.environment}`,
+    );
+
+    this.taskDefinition.addContainer(`Backend-Task-Container`, {
+      image: ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
+      memoryLimitMiB: 512,
+      portMappings: [
+        {
+          containerPort: 80,
+          hostPort: 80,
+          protocol: Protocol.TCP,
+        },
+      ],
+    });
+  }
+}

--- a/lib/backend/BackendSecurityGroup.ts
+++ b/lib/backend/BackendSecurityGroup.ts
@@ -1,0 +1,37 @@
+import { Construct } from "constructs";
+import { Peer, Port, SecurityGroup, Vpc } from "aws-cdk-lib/aws-ec2";
+
+interface BackendSecurityGroupProps {
+  environment: string;
+  vpc: Vpc;
+}
+
+export class BackendSecurityGroup extends Construct {
+  public readonly securityGroup: SecurityGroup;
+
+  constructor(scope: Construct, id: string, props: BackendSecurityGroupProps) {
+    super(scope, id);
+
+    this.securityGroup = new SecurityGroup(
+      this,
+      `SecurityGroup-${props.environment}`,
+      {
+        vpc: props.vpc,
+        allowAllOutbound: true,
+        description: "Allow HTTP from anywhere (IPv4 and IPv6)",
+      },
+    );
+
+    this.securityGroup.addIngressRule(
+      Peer.anyIpv4(),
+      Port.tcp(80),
+      "Allow HTTP IPv4",
+    );
+
+    this.securityGroup.addIngressRule(
+      Peer.anyIpv6(),
+      Port.tcp(80),
+      "Allow HTTP IPv6",
+    );
+  }
+}

--- a/lib/backend/BackendStack.ts
+++ b/lib/backend/BackendStack.ts
@@ -39,7 +39,7 @@ export class BackendStack extends Stack {
       {
         vpc: props.vpc,
         vpcSubnets: props.vpc.selectSubnets({
-          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+          subnetType: SubnetType.PUBLIC,
         }),
         instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
         machineImage: EcsOptimizedImage.amazonLinux2(),

--- a/lib/backend/BackendStack.ts
+++ b/lib/backend/BackendStack.ts
@@ -1,6 +1,10 @@
 import { Stack } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { Cluster, EcsOptimizedImage } from "aws-cdk-lib/aws-ecs";
+import {
+  AsgCapacityProvider,
+  Cluster,
+  EcsOptimizedImage,
+} from "aws-cdk-lib/aws-ecs";
 import {
   InstanceClass,
   InstanceSize,
@@ -19,9 +23,11 @@ export class BackendStack extends Stack {
   constructor(scope: Construct, id: string, props: BackendStackProps) {
     super(scope, id);
 
-    const ecs = new Cluster(this, `Backend-Cluster-${props.environment}`, {
-      vpc: props.vpc,
-    });
+    const cluster = new Cluster(
+      this,
+      `Backend-Cluster-${props.environment}`,
+      {},
+    );
 
     const autoScalingGroup = new AutoScalingGroup(
       this,
@@ -36,5 +42,13 @@ export class BackendStack extends Stack {
         desiredCapacity: 1,
       },
     );
+
+    const capacityProvider = new AsgCapacityProvider(
+      this,
+      `Backend-ASG-CapacityProvider-${props.environment}`,
+      { autoScalingGroup: autoScalingGroup },
+    );
+
+    cluster.addAsgCapacityProvider(capacityProvider);
   }
 }

--- a/lib/backend/BackendStack.ts
+++ b/lib/backend/BackendStack.ts
@@ -3,7 +3,11 @@ import { Construct } from "constructs";
 import {
   AsgCapacityProvider,
   Cluster,
+  ContainerImage,
+  Ec2Service,
+  Ec2TaskDefinition,
   EcsOptimizedImage,
+  Protocol,
 } from "aws-cdk-lib/aws-ecs";
 import {
   InstanceClass,
@@ -50,5 +54,26 @@ export class BackendStack extends Stack {
     );
 
     cluster.addAsgCapacityProvider(capacityProvider);
+
+    const taskDefinition = new Ec2TaskDefinition(
+      this,
+      `Backend-TaskDef-${props.environment}`,
+    );
+
+    taskDefinition.addContainer(`Backend-Task-Container`, {
+      image: ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
+      memoryLimitMiB: 512,
+      portMappings: [
+        {
+          containerPort: 80,
+          protocol: Protocol.TCP,
+        },
+      ],
+    });
+
+    new Ec2Service(this, `Backend-Service-${props.environment}`, {
+      cluster: cluster,
+      taskDefinition: taskDefinition,
+    });
   }
 }

--- a/lib/backend/BackendStack.ts
+++ b/lib/backend/BackendStack.ts
@@ -1,0 +1,19 @@
+import { Stack } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { Cluster } from "aws-cdk-lib/aws-ecs";
+import { Vpc } from "aws-cdk-lib/aws-ec2";
+
+interface BackendStackProps {
+  environment: string;
+  vpc: Vpc;
+}
+
+export class BackendStack extends Stack {
+  constructor(scope: Construct, id: string, props: BackendStackProps) {
+    super(scope, id);
+
+    const ecs = new Cluster(this, `BackendCluster-${props.environment}`, {
+      vpc: props.vpc,
+    });
+  }
+}

--- a/lib/backend/BackendStack.ts
+++ b/lib/backend/BackendStack.ts
@@ -1,7 +1,14 @@
 import { Stack } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { Cluster } from "aws-cdk-lib/aws-ecs";
-import { Vpc } from "aws-cdk-lib/aws-ec2";
+import { Cluster, EcsOptimizedImage } from "aws-cdk-lib/aws-ecs";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import { AutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 
 interface BackendStackProps {
   environment: string;
@@ -12,8 +19,22 @@ export class BackendStack extends Stack {
   constructor(scope: Construct, id: string, props: BackendStackProps) {
     super(scope, id);
 
-    const ecs = new Cluster(this, `BackendCluster-${props.environment}`, {
+    const ecs = new Cluster(this, `Backend-Cluster-${props.environment}`, {
       vpc: props.vpc,
     });
+
+    const autoScalingGroup = new AutoScalingGroup(
+      this,
+      `Backend-AutoScaling-Group-${props.environment}`,
+      {
+        vpc: props.vpc,
+        vpcSubnets: props.vpc.selectSubnets({
+          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        }),
+        instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+        machineImage: EcsOptimizedImage.amazonLinux2(),
+        desiredCapacity: 1,
+      },
+    );
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 작업 내용
ECS를 통한 인프라 추가
Task로 aws ecs-sample 이미지를 가져오도록 구현
보안 그룹을 80번 포트로 모든 요청을 허용하도록 구현

## ✅ 체크리스트

- [x] 기능이 정상적으로 작동하는지 테스트했습니다.
- [x] 필요하다면 문서(README 등)를 업데이트했습니다.
- [x] 중복된 코드나 불필요한 파일을 정리했습니다.
- [x] PR 제목과 커밋 메시지가 컨벤션에 맞게 작성되었습니다.

## 💬 기타 참고 사항
현재 Task의 이미지가 aws-ecs-sample로 웹 서버를 띄우도록 되어 있습니다. 이는 추후에 BE 파이프라인을 구성하여 build된 후 ECR의 이미지를 불러오도록 수정해야 합니다.