### PR TITLE
ECS용 LoadBalancer 추가

### DIFF
--- a/lib/backend/BackendLoadBalancer.ts
+++ b/lib/backend/BackendLoadBalancer.ts
@@ -1,0 +1,48 @@
+import { Duration, Stack } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { ApplicationLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Ec2Service } from "aws-cdk-lib/aws-ecs";
+
+interface BackendLoadBalancerProps {
+  environment: string;
+  vpc: Vpc;
+  securityGroup: SecurityGroup;
+  target: Ec2Service;
+}
+
+export class BackendLoadBalancer extends Stack {
+  constructor(scope: Construct, id: string, props: BackendLoadBalancerProps) {
+    super(scope, id);
+
+    const lb = new ApplicationLoadBalancer(
+      this,
+      `Backend-ApplicationLoadBalancer-${props.environment}`,
+      {
+        vpc: props.vpc,
+        vpcSubnets: props.vpc.selectSubnets({
+          subnetType: SubnetType.PUBLIC,
+        }),
+        securityGroup: props.securityGroup,
+        internetFacing: true,
+      },
+    );
+
+    const listener = lb.addListener(
+      `Backend-ApplicationLoadBalancer-Listener-${props.environment}`,
+      { port: 80 },
+    );
+
+    listener.addTargets(
+      `Backend-ApplicationLoadBalancer-Target-${props.environment}`,
+      {
+        port: 80,
+        targets: [props.target],
+        healthCheck: {
+          path: "/",
+          interval: Duration.seconds(30),
+        },
+      },
+    );
+  }
+}

--- a/lib/backend/BackendSecurityGroup.ts
+++ b/lib/backend/BackendSecurityGroup.ts
@@ -7,14 +7,15 @@ interface BackendSecurityGroupProps {
 }
 
 export class BackendSecurityGroup extends Construct {
-  public readonly securityGroup: SecurityGroup;
+  public readonly loadBalancerSecurityGroup: SecurityGroup;
+  public readonly ecsSecurityGroup: SecurityGroup;
 
   constructor(scope: Construct, id: string, props: BackendSecurityGroupProps) {
     super(scope, id);
 
-    this.securityGroup = new SecurityGroup(
+    this.loadBalancerSecurityGroup = new SecurityGroup(
       this,
-      `SecurityGroup-${props.environment}`,
+      `Backend-LoadBalancer-SecurityGroup-${props.environment}`,
       {
         vpc: props.vpc,
         allowAllOutbound: true,
@@ -22,16 +23,32 @@ export class BackendSecurityGroup extends Construct {
       },
     );
 
-    this.securityGroup.addIngressRule(
+    this.loadBalancerSecurityGroup.addIngressRule(
       Peer.anyIpv4(),
       Port.tcp(80),
       "Allow HTTP IPv4",
     );
 
-    this.securityGroup.addIngressRule(
+    this.loadBalancerSecurityGroup.addIngressRule(
       Peer.anyIpv6(),
       Port.tcp(80),
       "Allow HTTP IPv6",
+    );
+
+    this.ecsSecurityGroup = new SecurityGroup(
+      this,
+      `Backend-ECS-SecurityGroup-${props.environment}`,
+      {
+        vpc: props.vpc,
+        allowAllOutbound: true,
+        description: "Allow HTTP from LoadBalancer",
+      },
+    );
+
+    this.ecsSecurityGroup.addIngressRule(
+      this.loadBalancerSecurityGroup,
+      Port.tcp(80),
+      "Allow HTTP from Loadbalancer",
     );
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 작업 내용
ECS용 LoadBalancer 추가
SecurityGroup을 통해 LB에서만 퍼블릭 접근이 가능하도록 수정
기존의 ECS는 inbound를 LB의 보안그룹으로 지정

## ✅ 체크리스트

- [x] 기능이 정상적으로 작동하는지 테스트했습니다.
- [x] 필요하다면 문서(README 등)를 업데이트했습니다.
- [x] 중복된 코드나 불필요한 파일을 정리했습니다.
- [x] PR 제목과 커밋 메시지가 컨벤션에 맞게 작성되었습니다.